### PR TITLE
missing complex coefficient to Fresnel cylindrical propagator

### DIFF
--- a/axiprop/lib.py
+++ b/axiprop/lib.py
@@ -517,11 +517,12 @@ class PropagatorResamplingFresnel(CommonTools, StepperFresnel):
             * _norm_coef[None,:]
         self.TM = self.bcknd.inv_on_host(self.TM, dtype)
         self.TM = self.TM[:,:Nr]
+        self.TM *= 2 * np.pi * (-1j)**mode
 
         self.TM = self.bcknd.to_device(self.TM)
 
-        self.shape_trns = (Nr, )
-        self.shape_trns_new = (Nr_new, )
+        self.shape_trns = (Nr,)
+        self.shape_trns_new = (Nr_new,)
 
         self.u_loc = self.bcknd.zeros(Nr, dtype)
         self.u_ht = self.bcknd.zeros(Nkr_new, dtype)
@@ -533,7 +534,6 @@ class PropagatorResamplingFresnel(CommonTools, StepperFresnel):
         Forward QDHT transform.
         """
         self.u_ht = self.TST_matmul(self.TM, self.u_loc, self.u_ht)
-        self.u_ht *= 2 * np.pi
 
     def get_local_grid(self, dz, ikz):
         r_loc = dz * self.kr[:self.Nkr_new] / self.kz[ikz]

--- a/axiprop/simulation/lib.py
+++ b/axiprop/simulation/lib.py
@@ -55,7 +55,10 @@ class PropagatorSymmetricStepping(
         alpha = self.alpha
         alpha_np1 = self.alpha_np1
 
-        self._j_stepping = self.bcknd.to_device( np.abs(jn(mode+1, alpha)) / Rmax )[:Nr_new]
+        self._j_stepping = self.bcknd.to_device(
+            np.abs(jn(mode+1, alpha)) / Rmax
+        )[:Nr_new]
+
         denominator = alpha_np1 * np.abs(jn(mode+1, alpha[:,None]) \
                                        * jn(mode+1, alpha[None,:]))
 
@@ -64,7 +67,9 @@ class PropagatorSymmetricStepping(
 
         self.TM_stepping = self.bcknd.to_device(TM[:,:Nr_new], dtype)
 
-        self.TST_stepping_matmul = self.bcknd.make_matmul(self.TM_stepping, self.u_iht, self.u_ht)
+        self.TST_stepping_matmul = self.bcknd.make_matmul(
+            self.TM_stepping, self.u_iht, self.u_ht
+        )
 
     def TST_stepping(self):
         """


### PR DESCRIPTION
it appears that for m>0 a complex factor has to be applied in the Fresnel integral in the cylindrical coordinates (before it was only 2*pi). To be tested