### PR TITLE
boundary conditions in case of rescaling for strongly diffracting pulse

### DIFF
--- a/axiprop/common.py
+++ b/axiprop/common.py
@@ -45,6 +45,7 @@ class CommonTools:
     """
 
     def init_backend(self, backend, verbose):
+        self.verbose = verbose
 
         if verbose:
             print('Available backends are: ' \

--- a/axiprop/common.py
+++ b/axiprop/common.py
@@ -189,6 +189,9 @@ class CommonTools:
         r += 0.5 * dr
         return r, Rmax, Nr
 
+    def check_uniform(self, r):
+        return np.allclose( np.diff(r), np.diff(r).mean())
+
     def init_xy_uniform(self, x_axis, y_axis):
         """
         Setup the transverse `x` and `y` grids

--- a/axiprop/lib.py
+++ b/axiprop/lib.py
@@ -169,7 +169,7 @@ class PropagatorResampling(CommonTools, StepperNonParaxial):
     def __init__(self, r_axis, kz_axis,
                  r_axis_new=None, mode=0,
                  dtype=np.complex128,
-                 boundary_r_new=False,
+                 rmax_boundary=None,
                  backend=None, verbose=True):
         """
         Construct the propagator.
@@ -240,10 +240,12 @@ class PropagatorResampling(CommonTools, StepperNonParaxial):
         else:
             self.r_new, self.Rmax_new, self.Nr_new = self.init_r_sampled(r_axis_new)
 
-        if boundary_r_new:
-            self.init_kr(self.Rmax_new, self.Nr)
+        if rmax_boundary is None:
+            Rmax_boundary = self.Rmax  #np.max([self.Rmax, self.Rmax_new])
         else:
-            self.init_kr(self.Rmax, self.Nr)
+            Rmax_boundary = rmax_boundary
+
+        self.init_kr(Rmax_boundary, self.Nr)
 
         self.init_TST()
 

--- a/axiprop/lib.py
+++ b/axiprop/lib.py
@@ -239,11 +239,11 @@ class PropagatorResampling(CommonTools, StepperNonParaxial):
             elif r_axes_types[0]=='uniform':
                 self.r, self.Rmax, self.Nr = self.init_r_uniform(r_axis)
             else:
-                raise NameError
+                raise NameError("`r_axes_types` can be either `'uniform'` or `'bessel'`")
         elif type(r_axis) is np.ndarray:
             self.r, self.Rmax, self.Nr = self.init_r_sampled(r_axis)
         else:
-            raise TypeError
+            raise TypeError("`r_axis` can be either tuple or 1d-ndarray")
 
         if r_axis_new is None:
             self.r_new, self.Rmax_new, self.Nr_new = self.r, self.Rmax, self.Nr
@@ -253,17 +253,22 @@ class PropagatorResampling(CommonTools, StepperNonParaxial):
             elif r_axes_types[1]=='uniform':
                 self.r_new, self.Rmax_new, self.Nr_new = self.init_r_uniform(r_axis_new)
             else:
-                raise NameError
+                raise NameError("`r_axes_types` can be either `'uniform'` or `'bessel'`")
         elif type(r_axis_new) is np.ndarray:
             self.r_new, self.Rmax_new, self.Nr_new = self.init_r_sampled(r_axis_new)
         else:
-            raise TypeError
+            raise TypeError("`r_axis_new` can be either tuple, 1d-ndarray or `None`")
 
         if self.Rmax_new<=self.Rmax:
             self.r_ext = self.r.copy()
             self.Nr_ext = self.Nr
             self.Rmax_ext = self.Rmax
         else:
+            if self.verbose:
+                print (
+                    'Input r-grid is smaller, than the output one, and will be padded'
+                )
+
             if type(r_axis) is tuple:
                 if r_axes_types[0]=='bessel':
                     raise NotImplementedError(
@@ -300,7 +305,7 @@ class PropagatorResampling(CommonTools, StepperNonParaxial):
         """
         Nr = self.Nr
         Nr_new = self.Nr_new
-        r = self.r_ext # !!
+        r = self.r_ext # potentially use extended grid
         r_new = self.r_new
         kr = self.kr
         dtype = self.dtype

--- a/axiprop/lib.py
+++ b/axiprop/lib.py
@@ -169,6 +169,7 @@ class PropagatorResampling(CommonTools, StepperNonParaxial):
     def __init__(self, r_axis, kz_axis,
                  r_axis_new=None, mode=0,
                  dtype=np.complex128,
+                 boundary_r_new=False,
                  backend=None, verbose=True):
         """
         Construct the propagator.
@@ -239,7 +240,11 @@ class PropagatorResampling(CommonTools, StepperNonParaxial):
         else:
             self.r_new, self.Rmax_new, self.Nr_new = self.init_r_sampled(r_axis_new)
 
-        self.init_kr(self.Rmax, self.Nr)
+        if boundary_r_new:
+            self.init_kr(self.Rmax_new, self.Nr)
+        else:
+            self.init_kr(self.Rmax, self.Nr)
+
         self.init_TST()
 
     def init_TST(self):


### PR DESCRIPTION
for the resampling RT propagator in the pulse diffraction case, i.e. when initial `Rmax` is much smaller than `Rmax_new`, the reflective boundary conditions applied by the spectral solver at `Rmax` mess up the result. Testing the solutions..