### PR TITLE
patch for a bug with array casting in CL

### DIFF
--- a/axiprop/simulation/plasma.py
+++ b/axiprop/simulation/plasma.py
@@ -86,7 +86,11 @@ class PlasmaRelativistic:
         self.dens_func = dens_func
         self.sim = sim
         self.wake = wake
-        self.coef_RHS = -0.5 * mu_0 * sim.prop.omega * sim.prop.k_z_inv
+
+        omega = sim.prop.bcknd.to_host(sim.prop.omega)
+        k_z_inv = sim.prop.bcknd.to_host(sim.prop.k_z_inv)
+        self.coef_RHS = -0.5 * mu_0 * omega * k_z_inv
+        self.coef_RHS = sim.prop.bcknd.to_device(self.coef_RHS)
 
     def get_RHS(self, E_ts, dz=0.0 ):
         sim = self.sim

--- a/axiprop/simulation/solvers.py
+++ b/axiprop/simulation/solvers.py
@@ -137,7 +137,7 @@ class SolverBase(Diagnostics):
         i_diag += 1
         do_diag_next = False
 
-        while (self.z_loc <= self.z_0 + Lz) and self.is_finite(En_ts):
+        while (self.z_loc <= self.z_0 + Lz): # and self.is_finite(En_ts):
             # simulation step
             En_ts, err, iterations = self._step(
                 En_ts, dz,


### PR DESCRIPTION
patched a bug with array casting in CL
temporarly disabled NaN check for simulation runs (shouldn't be needed)